### PR TITLE
Change serialize method for compatibility with IE

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ module.exports = {
    * @api public
    */
 
-  serialize(token, options = {}) {
+  serialize(token, options) {
+    options = (typeof options !== 'undefined') ? options : {}
     return cookie.serialize(options.name || 'access_token', token, Object.assign({
       httpOnly: true,
       secure: true


### PR DESCRIPTION
The seralize function used a Javascript feature not present in IE. The seralize function takes two parameters: "token" and "options" with the "options" param having the default value of "{}" this feature is unavailable in IE. I've changed the function to work in IE. Instead of the function definition being: 
```javascript
seralize(token, options={}) 
```
I've changed it to
```javascript 
seralize(token, options)
```
and included the expression
```javascript
options = (typeof options !== 'undefined') ? options : {}
```
to prevent syntax errors in IE